### PR TITLE
Fixed UserPicture recycling issues

### DIFF
--- a/Habitica/src/com/habitrpg/android/habitica/userpicture/UserPicture.java
+++ b/Habitica/src/com/habitrpg/android/habitica/userpicture/UserPicture.java
@@ -175,6 +175,7 @@ public class UserPicture {
     private void generateImage(List<String> layerNames) {
         Integer layerNumber = 0;
         this.numOfTasks.set(layerNames.size());
+        layers.clear();
         for (String layer : layerNames) {
             layers.add(null);
             SpriteTarget target = new SpriteTarget(layerNumber, layer);

--- a/Habitica/src/com/habitrpg/android/habitica/userpicture/UserPicture.java
+++ b/Habitica/src/com/habitrpg/android/habitica/userpicture/UserPicture.java
@@ -38,7 +38,7 @@ public class UserPicture {
 
     private String currentCacheFileName;
 
-    List layers = new ArrayList();
+    final List<Bitmap> layers = new ArrayList<>();
 
     public UserPicture(HabitRPGUser user, Context context) {
         this.user = user;
@@ -176,7 +176,7 @@ public class UserPicture {
         Integer layerNumber = 0;
         this.numOfTasks.set(layerNames.size());
         for (String layer : layerNames) {
-            layers.add(0);
+            layers.add(null);
             SpriteTarget target = new SpriteTarget(layerNumber, layer);
             Picasso.with(this.context).load("https://habitica-assets.s3.amazonaws.com/mobileApp/images/" + layer + ".png").into(target);
             layerNumber = layerNumber + 1;

--- a/Habitica/src/com/habitrpg/android/habitica/userpicture/UserPicture.java
+++ b/Habitica/src/com/habitrpg/android/habitica/userpicture/UserPicture.java
@@ -92,8 +92,7 @@ public class UserPicture {
     }
 
     public void setPictureOn(final ImageView imageView) {
-        UserPicture.this.imageView = imageView;
-
+        this.imageView = imageView;
         List<String> layerNames = UserPicture.this.getLayerNames();
 
         final Bitmap cache = UserPicture.this.getCachedImage(layerNames);
@@ -104,9 +103,12 @@ public class UserPicture {
             return;
         }
 
+        // Clear out current image while loading the new one
+        imageView.setImageBitmap(null);
+        Picasso.with(context).cancelRequest(imageView);
+
         // no => generate it
         generateImage(layerNames);
-
     }
 
     public void setPictureWithRunnable(UserPictureRunnable runnable) {
@@ -121,6 +123,10 @@ public class UserPicture {
             return;
         }
 
+        // Clear out current image while loading the new one
+        runnable.run(null);
+
+        // no => generate it
         generateImage(layerNames);
     }
 


### PR DESCRIPTION
I noticed that scrolling through the party members list would cause the pictures to jump around from one to the next. I've implemented some basic fixes for the problem that properly cancels existing loads when a new one comes in.

UserId: 4334efc4-cdb2-4733-a2db-975a3d3e9824