### PR TITLE
Fix validation on TaskFormActivity

### DIFF
--- a/Habitica/src/com/habitrpg/android/habitica/TaskFormActivity.java
+++ b/Habitica/src/com/habitrpg/android/habitica/TaskFormActivity.java
@@ -187,7 +187,10 @@ public class TaskFormActivity extends AppCompatActivity implements AdapterView.O
         if (taskId != null) {
             Task task = new Select().from(Task.class).byIds(taskId).querySingle();
             this.task = task;
-            populate(task);
+            if(task != null){
+                populate(task);
+            }
+
             setTitle(task);
 
             btnDelete.setEnabled(true);


### PR DESCRIPTION
This should solve this issue: https://www.fabric.io/none11111111111398281637/android/apps/com.habitrpg.android.habitica/issues/566a09a8f5d3a7f76b3ffac9

The method `querySingle()` can return null and then we are having issues on the `populate` method.

https://github.com/Raizlabs/DBFlow/blob/be1570521d36f69c4dcffc921cf00c3a666d2da0/DBFlow/src/main/java/com/raizlabs/android/dbflow/sql/SqlUtils.java#L216-L228

https://github.com/Raizlabs/DBFlow/blob/be1570521d36f69c4dcffc921cf00c3a666d2da0/DBFlow/src/main/java/com/raizlabs/android/dbflow/sql/SqlUtils.java#L157-L170