### PR TITLE
Hide FloatingActionButton on scroll

### DIFF
--- a/Habitica/res/anim/fab_slide_in.xml
+++ b/Habitica/res/anim/fab_slide_in.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<set xmlns:android="http://schemas.android.com/apk/res/android">
+	<translate android:fromYDelta="100%" android:toYDelta="0%"/>
+</set>

--- a/Habitica/res/anim/fab_slide_out.xml
+++ b/Habitica/res/anim/fab_slide_out.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<set xmlns:android="http://schemas.android.com/apk/res/android">
+	<translate android:fromYDelta="0%" android:toYDelta="100%"/>
+</set>

--- a/Habitica/res/layout/activity_main.xml
+++ b/Habitica/res/layout/activity_main.xml
@@ -85,7 +85,7 @@
             android:layout_alignParentBottom="true"
             android:layout_alignParentRight="true"
             android:layout_marginBottom="16dp"
-            android:layout_marginRight="8dp" />
+            android:layout_marginRight="8dp"/>
 
     </android.support.design.widget.CoordinatorLayout>
 </android.support.v4.widget.DrawerLayout>

--- a/Habitica/res/layout/activity_main.xml
+++ b/Habitica/res/layout/activity_main.xml
@@ -85,7 +85,7 @@
             android:layout_alignParentBottom="true"
             android:layout_alignParentRight="true"
             android:layout_marginBottom="16dp"
-            android:layout_marginRight="8dp"/>
+            android:layout_marginRight="8dp" />
 
     </android.support.design.widget.CoordinatorLayout>
 </android.support.v4.widget.DrawerLayout>

--- a/Habitica/src/com/habitrpg/android/habitica/ui/helpers/FloatingActionMenuBehavior.java
+++ b/Habitica/src/com/habitrpg/android/habitica/ui/helpers/FloatingActionMenuBehavior.java
@@ -9,16 +9,29 @@ import android.support.v4.view.ViewCompat;
 import android.support.v4.view.ViewPropertyAnimatorListener;
 import android.util.AttributeSet;
 import android.view.View;
+import android.view.animation.Animation;
+import android.view.animation.AnimationUtils;
 
 import com.github.clans.fab.FloatingActionMenu;
+import com.habitrpg.android.habitica.R;
 
 import java.util.List;
 
 public class FloatingActionMenuBehavior extends CoordinatorLayout.Behavior {
+
+    private final int FAB_ANIMATION_DURATION = 500;
+
     private float mTranslationY;
+
+    private Context context;
+    private boolean isAnimating;
+    private boolean isOffScreen;
 
     public FloatingActionMenuBehavior(Context context, AttributeSet attrs) {
         super();
+        this.context = context;
+        isAnimating = false;
+        isOffScreen = false;
     }
 
     @Override
@@ -75,13 +88,53 @@ public class FloatingActionMenuBehavior extends CoordinatorLayout.Behavior {
 	}
 
 	@Override
-	public void onNestedScroll(CoordinatorLayout coordinatorLayout, View child, View target, int dxConsumed, int dyConsumed, int dxUnconsumed, int dyUnconsumed) {
+	public void onNestedScroll(CoordinatorLayout coordinatorLayout, final View child, View target, int dxConsumed, int dyConsumed, int dxUnconsumed, int dyUnconsumed) {
 		super.onNestedScroll(coordinatorLayout, child, target, dxConsumed, dyConsumed, dxUnconsumed, dyUnconsumed);
 
-		if (dyConsumed > 20 && child.getVisibility() == View.VISIBLE) {
-			child.setVisibility(View.INVISIBLE);
-		} else if (dyConsumed < -20 && child.getVisibility() != View.VISIBLE) {
-			child.setVisibility(View.VISIBLE);
+        /*
+        Logic:
+            - If we're scrolling downwards or we're at the bottom of the screen
+            AND if we're not animating and not on screen > HIDE
+         */
+        if ((dyConsumed > 20 || (dyConsumed == 0 && dyUnconsumed > 0)) && !isAnimating && !isOffScreen) {
+            isAnimating = true;
+            slideFabOffScreen(child);
+            resetAnimatingStatusWithDelay(child);
+            isOffScreen = true;
+
+        /*
+         Logic:
+            - If we're not on screen
+            AND we're scrolling upwards and not animating OR we're at the top of the screen > SHOW
+         */
+		} else if (isOffScreen && ((dyConsumed < -10 && !isAnimating) || dyUnconsumed < 0)) {
+            isAnimating = true;
+            slideFabOnScreen(child);
+            resetAnimatingStatusWithDelay(child);
+            isOffScreen = false;
 		}
 	}
+
+    private void resetAnimatingStatusWithDelay(View child) {
+        child.postDelayed(new Runnable() {
+			@Override
+			public void run() {
+				isAnimating = false;
+			}
+		}, FAB_ANIMATION_DURATION);
+    }
+
+    private void slideFabOffScreen(View view){
+        Animation slideOff = AnimationUtils.loadAnimation(context, R.anim.fab_slide_out);
+        slideOff.setDuration(FAB_ANIMATION_DURATION);
+        slideOff.setFillAfter(true);
+        view.startAnimation(slideOff);
+    }
+
+    private void slideFabOnScreen(View view){
+        Animation slideIn = AnimationUtils.loadAnimation(context, R.anim.fab_slide_in);
+        slideIn.setDuration(FAB_ANIMATION_DURATION);
+        slideIn.setFillAfter(true);
+        view.startAnimation(slideIn);
+    }
 }

--- a/Habitica/src/com/habitrpg/android/habitica/ui/helpers/FloatingActionMenuBehavior.java
+++ b/Habitica/src/com/habitrpg/android/habitica/ui/helpers/FloatingActionMenuBehavior.java
@@ -8,7 +8,6 @@ import android.support.design.widget.Snackbar;
 import android.support.v4.view.ViewCompat;
 import android.support.v4.view.ViewPropertyAnimatorListener;
 import android.util.AttributeSet;
-import android.util.Log;
 import android.view.View;
 
 import com.github.clans.fab.FloatingActionMenu;

--- a/Habitica/src/com/habitrpg/android/habitica/ui/helpers/FloatingActionMenuBehavior.java
+++ b/Habitica/src/com/habitrpg/android/habitica/ui/helpers/FloatingActionMenuBehavior.java
@@ -8,6 +8,7 @@ import android.support.design.widget.Snackbar;
 import android.support.v4.view.ViewCompat;
 import android.support.v4.view.ViewPropertyAnimatorListener;
 import android.util.AttributeSet;
+import android.util.Log;
 import android.view.View;
 
 import com.github.clans.fab.FloatingActionMenu;
@@ -67,4 +68,21 @@ public class FloatingActionMenuBehavior extends CoordinatorLayout.Behavior {
 
         return minOffset;
     }
+
+	@Override
+	public boolean onStartNestedScroll(CoordinatorLayout coordinatorLayout, View child, View directTargetChild, View target, int nestedScrollAxes) {
+		return nestedScrollAxes == ViewCompat.SCROLL_AXIS_VERTICAL ||
+				super.onStartNestedScroll(coordinatorLayout, child, directTargetChild, target, nestedScrollAxes);
+	}
+
+	@Override
+	public void onNestedScroll(CoordinatorLayout coordinatorLayout, View child, View target, int dxConsumed, int dyConsumed, int dxUnconsumed, int dyUnconsumed) {
+		super.onNestedScroll(coordinatorLayout, child, target, dxConsumed, dyConsumed, dxUnconsumed, dyUnconsumed);
+
+		if (dyConsumed > 20 && child.getVisibility() == View.VISIBLE) {
+			child.setVisibility(View.INVISIBLE);
+		} else if (dyConsumed < -20 && child.getVisibility() != View.VISIBLE) {
+			child.setVisibility(View.VISIBLE);
+		}
+	}
 }


### PR DESCRIPTION
After a certain amount of scrolling, the floating action button will hide, then a short scroll back up will bring the floating action button back into visibility.

I played with the numbers a bit, but feel the user would prefect the button to be visible for longer and hide less, so the scroll back up to bring the button back into visibility fit the best.

- kayliee

Re: https://github.com/HabitRPG/habitrpg-android/issues/234