### PR TITLE
Fixed accidentally introduced potential NPE

### DIFF
--- a/Habitica/src/com/habitrpg/android/habitica/userpicture/UserPicture.java
+++ b/Habitica/src/com/habitrpg/android/habitica/userpicture/UserPicture.java
@@ -66,10 +66,9 @@ public class UserPicture {
             Bitmap res = Bitmap.createBitmap(WIDTH, HEIGHT, Bitmap.Config.ARGB_8888);
             Canvas myCanvas = new Canvas(res);
             Integer layerNumber = 0;
-            for (Object layer : this.layers) {
-                if (layer.getClass() == Bitmap.class) {
-                    Bitmap layerBitmap = (Bitmap) layer;
-                    this.modifyCanvas(layerBitmap, myCanvas, layerNumber);
+            for (Bitmap layerBitmap : this.layers) {
+                if (layerBitmap != null) {
+                    modifyCanvas(layerBitmap, myCanvas, layerNumber);
                 }
                 layerNumber++;
             }


### PR DESCRIPTION
This can occur when loading an image where one of the layers doesn't load
correctly.