### PR TITLE
Fixes a checklist crash introduced by d6b6e897c.

### DIFF
--- a/Habitica/src/com/habitrpg/android/habitica/ui/adapter/HabitItemRecyclerViewAdapter.java
+++ b/Habitica/src/com/habitrpg/android/habitica/ui/adapter/HabitItemRecyclerViewAdapter.java
@@ -406,7 +406,7 @@ public class HabitItemRecyclerViewAdapter<THabitItem extends Task>
                 if (this.displayChecklist && this.Item.checklist != null) {
                     LayoutInflater layoutInflater = (LayoutInflater) context.getSystemService(Context.LAYOUT_INFLATER_SERVICE);
                     for (ChecklistItem item : this.Item.checklist) {
-                        LinearLayout itemView = (LinearLayout) layoutInflater.inflate(R.layout.checklist_item_row, this.checklistView);
+                        LinearLayout itemView = (LinearLayout) layoutInflater.inflate(R.layout.checklist_item_row, this.checklistView, false);
                         CheckBox checkbox = (CheckBox) itemView.findViewById(R.id.checkBox);
                         TextView textView = (TextView) itemView.findViewById(R.id.checkedTextView);
                         // Populate the data into the template view using the data object


### PR DESCRIPTION
Crash observed when expanding a checklist:

```
java.lang.IllegalStateException: The specified child already has a parent. You must call removeView() on the child's parent first.
	at android.view.ViewGroup.addViewInner(ViewGroup.java:4312)
	at android.view.ViewGroup.addView(ViewGroup.java:4148)
	at android.view.ViewGroup.addView(ViewGroup.java:4089)
	at android.view.ViewGroup.addView(ViewGroup.java:4062)
	at com.habitrpg.android.habitica.ui.adapter.HabitItemRecyclerViewAdapter$ChecklistedViewHolder.setDisplayChecklist(HabitItemRecyclerViewAdapter.java:418)
	at com.habitrpg.android.habitica.ui.adapter.HabitItemRecyclerViewAdapter$TodoViewHolder.setDisplayChecklist(HabitItemRecyclerViewAdapter.java:514)
	at com.habitrpg.android.habitica.ui.adapter.HabitItemRecyclerViewAdapter$ChecklistedViewHolder.onClick(HabitItemRecyclerViewAdapter.java:378)
	at android.view.View.performClick(View.java:5201)
	at android.view.View$PerformClick.run(View.java:21163)
	at android.os.Handler.handleCallback(Handler.java:746)
	at android.os.Handler.dispatchMessage(Handler.java:95)
	at android.os.Looper.loop(Looper.java:148)
	at android.app.ActivityThread.main(ActivityThread.java:5443)
	at java.lang.reflect.Method.invoke(Native Method)
	at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:728)
	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:618)
```

This is happening because d6b6e897c adds a parent when inflating
`itemView`. The default behavior is to attach the inflated view to its
parent, which conflicts with the later line explicitly adding the view.

My user id is: c7b4f8ee-085e-45c3-88de-db4fd41ca229

:)