### PR TITLE
Fix some fragment crashes.

### DIFF
--- a/Habitica/src/com/habitrpg/android/habitica/ui/fragments/BaseFragment.java
+++ b/Habitica/src/com/habitrpg/android/habitica/ui/fragments/BaseFragment.java
@@ -13,7 +13,10 @@ import android.widget.FrameLayout;
 
 import com.habitrpg.android.habitica.APIHelper;
 import com.habitrpg.android.habitica.ui.activities.MainActivity;
+import com.habitrpg.android.habitica.ui.activities.PrefsActivity;
 import com.magicmicky.habitrpgwrapper.lib.models.HabitRPGUser;
+import com.raizlabs.android.dbflow.sql.builder.Condition;
+import com.raizlabs.android.dbflow.sql.language.Select;
 
 import de.greenrobot.event.EventBus;
 import de.greenrobot.event.EventBusException;
@@ -57,8 +60,19 @@ public abstract class BaseFragment extends Fragment {
     }
 
     @Override
+    public void onViewStateRestored(Bundle savedInstanceState) {
+        super.onViewStateRestored(savedInstanceState);
+    }
+
+
+    @Override
     public View onCreateView(LayoutInflater inflater, ViewGroup container,
                              Bundle savedInstanceState) {
+
+        if (savedInstanceState != null && savedInstanceState.containsKey("userId")) {
+            String userId = savedInstanceState.getString("userId");
+            this.user = new Select().from(HabitRPGUser.class).where(Condition.column("id").eq(userId)).querySingle();
+        }
 
         if (tabLayout != null) {
             if (this.usesTabLayout) {
@@ -66,6 +80,10 @@ public abstract class BaseFragment extends Fragment {
             } else {
                 tabLayout.setVisibility(View.GONE);
             }
+        }
+
+        if (mAPIHelper == null) {
+            mAPIHelper = new APIHelper(PrefsActivity.fromContext(getContext()));
         }
 
         if (floatingMenuWrapper != null) {
@@ -99,6 +117,15 @@ public abstract class BaseFragment extends Fragment {
     @Override
     public void onCreateOptionsMenu(Menu menu, MenuInflater inflater) {
         super.onCreateOptionsMenu(menu, inflater);
+    }
+
+    @Override
+    public void onSaveInstanceState(Bundle outState) {
+        if (user != null) {
+            outState.putString("userId", user.getId());
+        }
+
+        super.onSaveInstanceState(outState);
     }
 
 

--- a/Habitica/src/com/habitrpg/android/habitica/ui/fragments/ChatListFragment.java
+++ b/Habitica/src/com/habitrpg/android/habitica/ui/fragments/ChatListFragment.java
@@ -16,6 +16,7 @@ import android.view.ViewGroup;
 import com.habitrpg.android.habitica.APIHelper;
 import com.habitrpg.android.habitica.HabiticaApplication;
 import com.habitrpg.android.habitica.ui.activities.MainActivity;
+import com.habitrpg.android.habitica.ui.activities.PrefsActivity;
 import com.habitrpg.android.habitica.R;
 import com.habitrpg.android.habitica.events.ToggledInnStateEvent;
 import com.habitrpg.android.habitica.events.commands.DeleteChatMessageCommand;
@@ -28,6 +29,8 @@ import com.habitrpg.android.habitica.ui.adapter.ChatRecyclerViewAdapter;
 import com.magicmicky.habitrpgwrapper.lib.models.ChatMessage;
 import com.magicmicky.habitrpgwrapper.lib.models.HabitRPGUser;
 import com.magicmicky.habitrpgwrapper.lib.models.PostChatMessageResult;
+import com.raizlabs.android.dbflow.sql.builder.Condition;
+import com.raizlabs.android.dbflow.sql.language.Select;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -70,6 +73,24 @@ public class ChatListFragment extends Fragment implements SwipeRefreshLayout.OnR
     @Nullable
     @Override
     public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
+        if (savedInstanceState != null) {
+          if (savedInstanceState.containsKey("groupId")) {
+            this.groupId = savedInstanceState.getString("groupId");
+          }
+
+          if (savedInstanceState.containsKey("isTavern")) {
+            this.isTavern = savedInstanceState.getBoolean("isTavern");
+          }
+
+          if (savedInstanceState.containsKey("userId")) {
+            this.userId = savedInstanceState.getString("userId");
+            if (this.userId != null) {
+              this.user = new Select().from(HabitRPGUser.class).where(Condition.column("id").eq(userId)).querySingle();
+            }
+          }
+
+        }
+
         if (view == null)
             view = inflater.inflate(R.layout.fragment_chatlist, container, false);
 
@@ -79,6 +100,10 @@ public class ChatListFragment extends Fragment implements SwipeRefreshLayout.OnR
             registerEventBus = true;
         } catch (EventBusException ignored) {
 
+        }
+
+        if (apiHelper == null) {
+            apiHelper = new APIHelper(PrefsActivity.fromContext(getContext()));
         }
 
         return view;
@@ -249,5 +274,12 @@ public class ChatListFragment extends Fragment implements SwipeRefreshLayout.OnR
         super.onDestroyView();
     }
 
+    @Override
+    public void onSaveInstanceState(Bundle outState) {
+        outState.putString("userId", this.userId);
+        outState.putString("groupId", this.groupId);
+        outState.putBoolean("isTavern", this.isTavern);
+        super.onSaveInstanceState(outState);
+    }
 
 }


### PR DESCRIPTION
The new-ish `configure` pattern used on fragments (e.g. from c3d22a9) causes crashes if the application is stopped and then later resumed.

Steps to reproduce:

1. In "Developer Options," enable the "Don't keep activities" setting. This will make every activity be destroyed and created anew when put into the background, as if due to memory pressure.
2. Open the "Tavern" from the side bar.
3. Put the app in the background.
4. Put the app back into the foreground and observe:

```
FATAL EXCEPTION: main
Process: com.habitrpg.android.habitica.debug, PID: 2673
AndroidRuntime: java.lang.RuntimeException: Unable to start activity ComponentInfo{com.habitrpg.android.habitica.debug/com.habitrpg.android.habitica.ui.activities.MainActivity}: java.lang.NullPointerException: Attempt to invoke virtual method 'java.lang.String com.magicmicky.habitrpgwrapper.lib.models.HabitRPGUser.getId()' on a null object reference
	at android.app.ActivityThread.performLaunchActivity(ActivityThread.java:2426)
	at android.app.ActivityThread.handleLaunchActivity(ActivityThread.java:2490)
	at android.app.ActivityThread.-wrap11(ActivityThread.java)
	at android.app.ActivityThread$H.handleMessage(ActivityThread.java:1354)
	at android.os.Handler.dispatchMessage(Handler.java:102)
	at android.os.Looper.loop(Looper.java:148)
	at android.app.ActivityThread.main(ActivityThread.java:5443)
	at java.lang.reflect.Method.invoke(Native Method)
	at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:728)
	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:618)
Caused by: java.lang.NullPointerException: Attempt to invoke virtual method 'java.lang.String com.magicmicky.habitrpgwrapper.lib.models.HabitRPGUser.getId()' on a null object reference
	at com.habitrpg.android.habitica.ui.fragments.ChatListFragment.configure(ChatListFragment.java:63)
	at com.habitrpg.android.habitica.ui.fragments.TavernFragment.onCreateView(TavernFragment.java:25)
	at android.support.v4.app.Fragment.performCreateView(Fragment.java:1962)
	at android.support.v4.app.FragmentManagerImpl.moveToState(FragmentManager.java:1067)
	at android.support.v4.app.FragmentManagerImpl.moveToState(FragmentManager.java:1248)
	at android.support.v4.app.FragmentManagerImpl.moveToState(FragmentManager.java:1230)
	at android.support.v4.app.FragmentManagerImpl.dispatchActivityCreated(FragmentManager.java:2042)
	at android.support.v4.app.FragmentController.dispatchActivityCreated(FragmentController.java:165)
	at android.support.v4.app.FragmentActivity.onStart(FragmentActivity.java:543)
	at android.app.Instrumentation.callActivityOnStart(Instrumentation.java:1260)
	at android.app.Activity.performStart(Activity.java:6261)
	at android.app.ActivityThread.performLaunchActivity(ActivityThread.java:2389)
	... 9 more
```

Since the Activity and its Fragments were destroyed, they needed to be recreated. But the `configure` flow never gets called, so our Fragments are full of nulls -- e.g. user, apiHelper in this case.

This fix uses the `onSaveInstanceState` mechanism for storing data that can be restored when the Fragments are being re-created.

There are more crashes like this, I'm pretty sure, but these are the ones I could tackle tonight!

User id: c7b4f8ee-085e-45c3-88de-db4fd41ca229

:)