### PR TITLE
Fix for broken travis build

### DIFF
--- a/Habitica/res/values/secret_strings.xml
+++ b/Habitica/res/values/secret_strings.xml
@@ -2,4 +2,5 @@
 <resources>
     <string name="fabric_key">CHANGE_ME</string>
     <string name="facebook_app_id">CHANGE_ME</string>
+    <string name="amplitude_app_id">CHANGE_ME</string>
 </resources>


### PR DESCRIPTION
The resource amplitude_app_id is missing and is causing build failures.