### PR TITLE
Crash on recreate MainActivity, and blank tabs

### DIFF
--- a/Habitica/src/com/habitrpg/android/habitica/ui/activities/MainActivity.java
+++ b/Habitica/src/com/habitrpg/android/habitica/ui/activities/MainActivity.java
@@ -182,6 +182,15 @@ public class MainActivity extends BaseActivity implements HabitRPGUserCallback.O
                 this.mAPIHelper.retrieveUser(new HabitRPGUserCallback(this));
             }
         }
+
+        //after the activity has been stopped and is thereafter resumed,
+        //a state can arise in which the active fragment no longer has a
+        //reference to the tabLayout (and all its adapters are null).
+        //Recreate the fragment as a result.
+        if (activeFragment != null && activeFragment.tabLayout == null){
+            activeFragment = null;
+            drawer.setSelectionAtPosition(1);
+        }
     }
 
     private void setupCheckout() {

--- a/Habitica/src/com/habitrpg/android/habitica/ui/fragments/tasks/TaskRecyclerViewFragment.java
+++ b/Habitica/src/com/habitrpg/android/habitica/ui/fragments/tasks/TaskRecyclerViewFragment.java
@@ -4,6 +4,7 @@ import android.os.Bundle;
 import android.support.annotation.Nullable;
 import android.support.v7.widget.LinearLayoutManager;
 import android.support.v7.widget.RecyclerView;
+import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -26,6 +27,7 @@ public class TaskRecyclerViewFragment extends BaseFragment implements View.OnCli
     public RecyclerView mRecyclerView;
     public RecyclerView.Adapter mAdapter;
     private String classType;
+    private static final String CLASS_TYPE_KEY = "CLASS_TYPE_KEY";
 
     // TODO needs a bit of cleanup
     public void SetInnerAdapter(HabitItemRecyclerViewAdapter adapter, String classType) {
@@ -39,6 +41,10 @@ public class TaskRecyclerViewFragment extends BaseFragment implements View.OnCli
     public View onCreateView(LayoutInflater inflater, @Nullable ViewGroup container, @Nullable Bundle savedInstanceState) {
         if (view == null) {
             view = inflater.inflate(R.layout.fragment_recyclerview, container, false);
+        }
+
+        if (savedInstanceState != null){
+            this.classType = savedInstanceState.getString(CLASS_TYPE_KEY, "");
         }
 
         switch (this.classType) {
@@ -84,6 +90,12 @@ public class TaskRecyclerViewFragment extends BaseFragment implements View.OnCli
         }
 
         mRecyclerView.setAdapter(mAdapter);
+    }
+
+    @Override
+    public void onSaveInstanceState(Bundle outState) {
+        super.onSaveInstanceState(outState);
+        outState.putString(CLASS_TYPE_KEY, this.classType);
     }
 
     public static TaskRecyclerViewFragment newInstance(HabitItemRecyclerViewAdapter adapter, String classType) {


### PR DESCRIPTION
This PR, consisting of two commits, fixes two issues I noticed on my N5X, with Android 6.0.1.

1. When returning to the app after the `MainActivity` has been destroyed, the app would crash (due to a null string that wasn't being saved in `onSaveInstanceState`).

2. After I fixed the first issue, the tabs would be blank in the same situation.

These issues appear to affect version 0.0.26, released on the Play Store on Feb 2, 2016, and issue two (at least) affected previous versions of the app (and bothered me enough that I decided to fix it myself).

To reproduce these issues on that version, go to developer settings and enable "**Don't keep activities**", open the app in the logged in state, scroll through the tabs, leave the app, wait a few moments, then open the app again. Issue one will then crash the app.

The solution to issue two is a little heavy (just recreating the tabs fragment), but no other minimally invasive solution successfully solved the problem.