### PR TITLE
add attributes to task creation if auto allocated

### DIFF
--- a/Habitica/res/layout/activity_task_form.xml
+++ b/Habitica/res/layout/activity_task_form.xml
@@ -95,10 +95,10 @@
             </LinearLayout>
 
             <LinearLayout
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:orientation="vertical"
-                    android:id="@+id/task_difficulty_wrapper">
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="vertical"
+                android:id="@+id/task_difficulty_wrapper">
                 <TextView
                     android:id="@+id/textView2"
                     android:layout_width="wrap_content"
@@ -109,6 +109,27 @@
 
                 <Spinner
                     android:id="@+id/task_difficulty_spinner"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content" />
+
+            </LinearLayout>
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="vertical"
+                android:layout_marginTop="20dp"
+                android:id="@+id/task_attribute_wrapper">
+                <TextView
+                    android:id="@+id/attribute_title_textview"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_gravity="center_vertical"
+                    android:text="@string/attributes"
+                    android:textAppearance="?android:attr/textAppearanceLarge" />
+
+                <Spinner
+                    android:id="@+id/task_attribute_spinner"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content" />
 

--- a/Habitica/res/values-de/strings.xml
+++ b/Habitica/res/values-de/strings.xml
@@ -69,6 +69,11 @@ Versuche sorgfältiger deine täglichen Aufgaben zu erledigen und bekomme diese 
   <string name="easy">Einfach</string>
   <string name="medium">Mittel</string>
   <string name="hard">Schwer</string>
+  <string name="attributes">Attribute</string>
+  <string name="physical">Körperlich</string>
+  <string name="mental">Mental</string>
+  <string name="social">Soziales</string>
+  <string name="other">Anderes</string>
   <string name="start_date">Starttermin</string>
   <string name="positive_habit_form">Positiv ( + )</string>
   <string name="negative_habit_form">Negativ ( - )</string>

--- a/Habitica/res/values-es/strings.xml
+++ b/Habitica/res/values-es/strings.xml
@@ -70,6 +70,11 @@
   <string name="easy">Fácil</string>
   <string name="medium">Intermedia</string>
   <string name="hard">Difícil</string>
+  <string name="attributes">Atributos</string>
+  <string name="physical">Físicos</string>
+  <string name="mental">Mentales</string>
+  <string name="social">Social</string>
+  <string name="other">Otro</string>
   <string name="start_date">Fecha de inicio</string>
   <string name="positive_habit_form">Positivo ( + )</string>
   <string name="negative_habit_form">Negativo ( - )</string>

--- a/Habitica/res/values-fr/strings.xml
+++ b/Habitica/res/values-fr/strings.xml
@@ -70,6 +70,11 @@
   <string name="easy">Facile</string>
   <string name="medium">Moyen</string>
   <string name="hard">Difficile</string>
+  <string name="attributes">Attributs</string>
+  <string name="physical">Physique</string>
+  <string name="mental">Mental</string>
+  <string name="social">Social</string>
+  <string name="other">Autres</string>
   <string name="start_date">Date de début</string>
   <string name="positive_habit_form">Positif ( + )</string>
   <string name="negative_habit_form">Négatif ( - )</string>

--- a/Habitica/res/values-it/strings.xml
+++ b/Habitica/res/values-it/strings.xml
@@ -70,6 +70,11 @@
   <string name="easy">Facile</string>
   <string name="medium">Medio</string>
   <string name="hard">Difficile</string>
+  <string name="attributes">Attributi</string>
+  <string name="physical">Fisico</string>
+  <string name="mental">Mentale</string>
+  <string name="social">Social</string>
+  <string name="other">Altro</string>
   <string name="start_date">Data di partenza</string>
   <string name="positive_habit_form">Positiva ( + )</string>
   <string name="negative_habit_form">Negativa ( - )</string>

--- a/Habitica/res/values-pl/strings.xml
+++ b/Habitica/res/values-pl/strings.xml
@@ -70,6 +70,11 @@
   <string name="easy">Łatwy</string>
   <string name="medium">Średni</string>
   <string name="hard">Trudny</string>
+  <string name="attributes">Atrybuty</string>
+  <string name="physical">Fizyczne</string>
+  <string name="mental">Mentalne</string>
+  <string name="social">Społeczność</string>
+  <string name="other">Inne</string>
   <string name="start_date">Data rozpoczęcia</string>
   <string name="positive_habit_form">Pozytywne ( + )</string>
   <string name="negative_habit_form">Negatywne ( - )</string>

--- a/Habitica/res/values-pt-rBR/strings.xml
+++ b/Habitica/res/values-pt-rBR/strings.xml
@@ -70,6 +70,11 @@
   <string name="easy">Fácil</string>
   <string name="medium">Médio</string>
   <string name="hard">Dificil</string>
+  <string name="attributes">Atributos</string>
+  <string name="physical">Físico</string>
+  <string name="mental">Mental</string>
+  <string name="social">Social</string>
+  <string name="other">Outros</string>
   <string name="start_date">Data de inicio</string>
   <string name="positive_habit_form">Positivo ( + )</string>
   <string name="negative_habit_form">Negativo ( + )</string>

--- a/Habitica/res/values-zh/strings.xml
+++ b/Habitica/res/values-zh/strings.xml
@@ -70,6 +70,11 @@
   <string name="easy">简单</string>
   <string name="medium">中等</string>
   <string name="hard">困难</string>
+  <string name="attributes">属性</string>
+  <string name="physical">生理上的</string>
+  <string name="mental">心理上的</string>
+  <string name="social">社交</string>
+  <string name="other">其他</string>
   <string name="start_date">开始日期</string>
   <string name="positive_habit_form">正面的(+)</string>
   <string name="negative_habit_form">负面的 (-)</string>

--- a/Habitica/res/values/strings.xml
+++ b/Habitica/res/values/strings.xml
@@ -86,6 +86,12 @@
     <string name="checklist">Checklist</string>
     <string name="actions">Actions</string>
 
+    <string name="attributes">Attributes</string>
+    <string name="physical">Physical</string>
+    <string name="mental">Mental</string>
+    <string name="social">Social</string>
+    <string name="other">Other</string>
+
     <string name="frequency">Frequency</string>
     <string name="frequency_weekly">On Certain Days of the Week</string>
     <string name="frequency_daily">Every X Days</string>

--- a/Habitica/res/values/values.xml
+++ b/Habitica/res/values/values.xml
@@ -15,6 +15,13 @@
         <item>@string/hard</item>
     </string-array>
 
+    <string-array name="task_attributes">
+        <item>@string/physical</item>
+        <item>@string/mental</item>
+        <item>@string/social</item>
+        <item>@string/other</item>
+    </string-array>
+
     <string-array name="daily_frequencies">
         <item>@string/frequency_weekly</item>
         <item>@string/frequency_daily</item>

--- a/Habitica/src/com/habitrpg/android/habitica/ui/activities/TaskFormActivity.java
+++ b/Habitica/src/com/habitrpg/android/habitica/ui/activities/TaskFormActivity.java
@@ -10,6 +10,7 @@ import android.support.v7.app.AlertDialog;
 import android.support.v7.widget.LinearLayoutManager;
 import android.support.v7.widget.RecyclerView;
 import android.support.v7.widget.helper.ItemTouchHelper;
+import android.text.TextUtils;
 import android.view.KeyEvent;
 import android.view.Menu;
 import android.view.MenuItem;
@@ -63,11 +64,17 @@ import butterknife.Bind;
 
 
 public class TaskFormActivity extends BaseActivity implements AdapterView.OnItemSelectedListener {
+    public static final String TASK_ID_KEY = "taskId";
+    public static final String TASK_TYPE_KEY = "type";
+    public static final String TAG_IDS_KEY = "tagsId";
+    public static final String TAG_NAMES_KEY = "tagsName";
+    public static final String ALLOCATION_MODE_KEY = "allocationModeKey";
 
     private String taskType;
     private String taskId;
     private Task task;
 
+    private String allocationMode;
     private List<CheckBox> weekdayCheckboxes = new ArrayList<>();
     private NumberPicker frequencyPicker;
     private List<String> tags;
@@ -92,6 +99,9 @@ public class TaskFormActivity extends BaseActivity implements AdapterView.OnItem
     @Bind(R.id.task_difficulty_wrapper)
     LinearLayout difficultyWrapper;
 
+    @Bind(R.id.task_attribute_wrapper)
+    LinearLayout attributeWrapper;
+
     @Bind(R.id.task_main_wrapper)
     LinearLayout mainWrapper;
 
@@ -103,6 +113,9 @@ public class TaskFormActivity extends BaseActivity implements AdapterView.OnItem
 
     @Bind(R.id.task_difficulty_spinner)
     Spinner taskDifficultySpinner;
+
+    @Bind(R.id.task_attribute_spinner)
+    Spinner taskAttributeSpinner;
 
     @Bind(R.id.btn_delete_task)
     Button btnDelete;
@@ -176,10 +189,11 @@ public class TaskFormActivity extends BaseActivity implements AdapterView.OnItem
 
         Intent intent = getIntent();
         Bundle bundle = intent.getExtras();
-        taskType = bundle.getString("type");
-        taskId = bundle.getString("taskId");
-        tags = bundle.getStringArrayList("tagsId");
-        tagsName = bundle.getStringArrayList("tagsName");
+        taskType = bundle.getString(TASK_TYPE_KEY);
+        taskId = bundle.getString(TASK_ID_KEY);
+        tags = bundle.getStringArrayList(TAG_IDS_KEY);
+        tagsName = bundle.getStringArrayList(TAG_NAMES_KEY);
+        allocationMode = bundle.getString(ALLOCATION_MODE_KEY);
         userSelectedTags = new ArrayList<CharSequence>();
         allTags = new ArrayList<CheckBox>();
         userSelectedTagIds = new ArrayList<String>();
@@ -216,11 +230,17 @@ public class TaskFormActivity extends BaseActivity implements AdapterView.OnItem
             }
         });
 
-        ArrayAdapter<CharSequence> adapter = ArrayAdapter.createFromResource(this,
+        ArrayAdapter<CharSequence> difficultyAdapter = ArrayAdapter.createFromResource(this,
                 R.array.task_difficulties, android.R.layout.simple_spinner_item);
-        adapter.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item);
-        taskDifficultySpinner.setAdapter(adapter);
+        difficultyAdapter.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item);
+        taskDifficultySpinner.setAdapter(difficultyAdapter);
         taskDifficultySpinner.setSelection(1);
+
+        ArrayAdapter<CharSequence> attributeAdapter = ArrayAdapter.createFromResource(this,
+                R.array.task_attributes, android.R.layout.simple_spinner_item);
+        attributeAdapter.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item);
+        taskAttributeSpinner.setAdapter(attributeAdapter);
+        taskAttributeSpinner.setSelection(0);
 
         //Filling in the tags check boxes
         //If tags list is empty, we don't allow user to select a tag.
@@ -231,6 +251,10 @@ public class TaskFormActivity extends BaseActivity implements AdapterView.OnItem
         }
         else {
             createTagsCheckBoxes();
+        }
+
+        if (TextUtils.isEmpty(allocationMode) || !allocationMode.equals("taskbased")){
+            attributeWrapper.setVisibility(View.GONE);
         }
 
         if (taskType.equals("habit")) {
@@ -279,6 +303,7 @@ public class TaskFormActivity extends BaseActivity implements AdapterView.OnItem
             mainWrapper.removeView(checklistWrapper);
 
             difficultyWrapper.setVisibility(View.GONE);
+            attributeWrapper.setVisibility(View.GONE);
         }
 
         if (taskId != null) {
@@ -605,6 +630,24 @@ public class TaskFormActivity extends BaseActivity implements AdapterView.OnItem
             this.taskDifficultySpinner.setSelection(3);
         }
 
+        String attribute = task.getAttribute();
+        if (attribute != null){
+            switch (attribute){
+                case Task.ATTRIBUTE_STRENGTH:
+                    taskAttributeSpinner.setSelection(0);
+                    break;
+                case Task.ATTRIBUTE_INTELLIGENCE:
+                    taskAttributeSpinner.setSelection(1);
+                    break;
+                case Task.ATTRIBUTE_CONSTITUTION:
+                    taskAttributeSpinner.setSelection(2);
+                    break;
+                case Task.ATTRIBUTE_PERCEPTION:
+                    taskAttributeSpinner.setSelection(3);
+                    break;
+            }
+        }
+
         if (task.type.equals("habit")) {
             positiveCheckBox.setChecked(task.getUp());
             negativeCheckBox.setChecked(task.getDown());
@@ -692,6 +735,25 @@ public class TaskFormActivity extends BaseActivity implements AdapterView.OnItem
             task.setPriority((float) 1.5);
         } else if (this.taskDifficultySpinner.getSelectedItemPosition() == 3) {
             task.setPriority((float) 2.0);
+        }
+
+        if (TextUtils.isEmpty(allocationMode) || !allocationMode.equals("taskbased")){
+            task.setAttribute(Task.ATTRIBUTE_STRENGTH);
+        }else {
+            switch (this.taskAttributeSpinner.getSelectedItemPosition()){
+                case 0:
+                    task.setAttribute(Task.ATTRIBUTE_STRENGTH);
+                    break;
+                case 1:
+                    task.setAttribute(Task.ATTRIBUTE_INTELLIGENCE);
+                    break;
+                case 2:
+                    task.setAttribute(Task.ATTRIBUTE_CONSTITUTION);
+                    break;
+                case 3:
+                    task.setAttribute(Task.ATTRIBUTE_PERCEPTION);
+                    break;
+            }
         }
 
         switch (task.type) {

--- a/Habitica/src/com/habitrpg/android/habitica/ui/fragments/tasks/TasksFragment.java
+++ b/Habitica/src/com/habitrpg/android/habitica/ui/fragments/tasks/TasksFragment.java
@@ -25,6 +25,7 @@ import android.widget.ImageView;
 import com.github.clans.fab.FloatingActionButton;
 import com.github.clans.fab.FloatingActionMenu;
 import com.habitrpg.android.habitica.ContentCache;
+import com.habitrpg.android.habitica.HabiticaApplication;
 import com.habitrpg.android.habitica.R;
 import com.habitrpg.android.habitica.callbacks.HabitRPGUserCallback;
 import com.habitrpg.android.habitica.callbacks.TaskCreationCallback;
@@ -415,11 +416,19 @@ public class TasksFragment extends BaseMainFragment implements OnCheckedChangeLi
         if (this.displayingTaskForm) {
             return;
         }
+
+        String allocationMode = "";
+        if (HabiticaApplication.User != null && HabiticaApplication.User.getPreferences() != null){
+            allocationMode = HabiticaApplication.User.getPreferences().getAllocationMode();
+        }
+
         Bundle bundle = new Bundle();
-        bundle.putString("type", event.Task.getType());
-        bundle.putString("taskId", event.Task.getId());
-        bundle.putStringArrayList("tagsId", new ArrayList<>(this.getTagIds()));
-        bundle.putStringArrayList("tagsName", new ArrayList<>(this.getTagNames()));
+        bundle.putString(TaskFormActivity.TASK_TYPE_KEY, event.Task.getType());
+        bundle.putString(TaskFormActivity.TASK_ID_KEY, event.Task.getId());
+        bundle.putString(TaskFormActivity.ALLOCATION_MODE_KEY, allocationMode);
+        bundle.putStringArrayList(TaskFormActivity.TAG_IDS_KEY, new ArrayList<>(this.getTagIds()));
+        bundle.putStringArrayList(TaskFormActivity.TAG_NAMES_KEY, new ArrayList<>(this.getTagNames()));
+
         Intent intent = new Intent(activity, TaskFormActivity.class);
         intent.putExtras(bundle);
         this.displayingTaskForm = true;

--- a/Habitica/src/com/magicmicky/habitrpgwrapper/lib/models/tasks/Task.java
+++ b/Habitica/src/com/magicmicky/habitrpgwrapper/lib/models/tasks/Task.java
@@ -34,6 +34,10 @@ public class Task extends BaseModel {
     public static final String TYPE_REWARD = "reward";
     public static final String FREQUENCY_WEEKLY = "weekly";
     public static final String FREQUENCY_DAILY = "daily";
+    public static final String ATTRIBUTE_STRENGTH = "str";
+    public static final String ATTRIBUTE_CONSTITUTION = "con";
+    public static final String ATTRIBUTE_INTELLIGENCE = "int";
+    public static final String ATTRIBUTE_PERCEPTION = "per";
 
     @Column
     @PrimaryKey


### PR DESCRIPTION
This PR consists of one commit that adds a spinner for setting a task's attribute if task-based point allocation is set for the user. This is a feature I use a lot, and I got tired of having to enter it in on the web. I will submit an iOS PR for the same in the next few days, to maintain parity between the apps.

It also includes the translation strings for the attribute values, either translated directly by me for languages I know reasonably well (en, de, fr), or taken from another Habitica repo with available translations (es, it, pl, pt, zh). I neither speak Lithuanian, nor could I find the translations for attributes in any of Habitica's repos, so that was not included in this PR.

My Habitica User-ID: 19095cf1-7620-4458-95cd-b4bd08fbe306