### PR TITLE
add attribute to new tasks if auto allocated

### DIFF
--- a/Habitica/src/main/java/com/habitrpg/android/habitica/ui/fragments/tasks/TasksFragment.java
+++ b/Habitica/src/main/java/com/habitrpg/android/habitica/ui/fragments/tasks/TasksFragment.java
@@ -371,10 +371,17 @@ public class TasksFragment extends BaseMainFragment implements OnCheckedChangeLi
         if (this.displayingTaskForm) {
             return;
         }
+
+        String allocationMode = "";
+        if (HabiticaApplication.User != null && HabiticaApplication.User.getPreferences() != null){
+            allocationMode = HabiticaApplication.User.getPreferences().getAllocationMode();
+        }
+
         Bundle bundle = new Bundle();
-        bundle.putString("type", type);
-        bundle.putStringArrayList("tagsId", new ArrayList<>(this.getTagIds()));
-        bundle.putStringArrayList("tagsName", new ArrayList<>(this.getTagNames()));
+        bundle.putString(TaskFormActivity.TASK_TYPE_KEY, type);
+        bundle.putStringArrayList(TaskFormActivity.TAG_IDS_KEY, new ArrayList<>(this.getTagIds()));
+        bundle.putStringArrayList(TaskFormActivity.TAG_NAMES_KEY, new ArrayList<>(this.getTagNames()));
+        bundle.putString(TaskFormActivity.ALLOCATION_MODE_KEY, allocationMode);
 
         Intent intent = new Intent(activity, TaskFormActivity.class);
         intent.putExtras(bundle);


### PR DESCRIPTION
This PR allows selecting an attribute on **new** tasks (as opposed to just existing tasks) if the user has enabled auto allocation. That it was not included in the first PR regarding task attributes was an oversight.