### PR TITLE
fix unit tests error caused by missing multidex test deps

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,8 @@
 language: android
-jdk:
-  - oraclejdk7
-  - oraclejdk8
+jdk: oraclejdk8
 before_install:
   - export JAVA7_HOME=/usr/lib/jvm/java-7-oracle
   - export JAVA8_HOME=/usr/lib/jvm/java-8-oracle
-  - export JAVA_HOME=$JAVA7_HOME
 
 android:
   components:

--- a/Habitica/build.gradle
+++ b/Habitica/build.gradle
@@ -106,6 +106,7 @@ dependencies {
 
     testCompile 'com.squareup.leakcanary:leakcanary-android-no-op:1.3.1'
     testCompile 'org.robolectric:robolectric:3.0'
+    testCompile 'org.robolectric:shadows-multidex:3.0'
 
     debugCompile 'com.squareup.leakcanary:leakcanary-android:1.3.1'
     releaseCompile 'com.squareup.leakcanary:leakcanary-android-no-op:1.3.1'


### PR DESCRIPTION
my Habitica User-ID: 51102111-ed4a-4f13-972b-705a3c1e5808

`./gradlew testDebugUnitTest` returns error:
`java.lang.RuntimeException: Multi dex installation failed`

Add the missing `org.robolectric:shadows-multidex` dependency to fix the problem.

-

fix Travis CI UnsupportedClassVersionError

	java.lang.UnsupportedClassVersionError: com/magicmicky/habitrpgwrapper/lib/utils/DateDeserializerTest : Unsupported major.minor version 52.0
	
- set Travis CI to use only JDK 8 as a temporary fix for [gradle-retrolambda bug](https://github.com/evant/gradle-retrolambda/issues/133)