### PR TITLE
Update guild state

### DIFF
--- a/Habitica/res/layout/item_public_guild.xml
+++ b/Habitica/res/layout/item_public_guild.xml
@@ -1,44 +1,47 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    android:orientation="vertical" android:layout_width="match_parent"
+<LinearLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:padding="@dimen/row_padding">
+    android:orientation="vertical"
+    android:padding="@dimen/row_padding"
+    android:background="?attr/selectableItemBackground">
 
     <LinearLayout
-        android:orientation="horizontal"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content">
+        android:layout_height="wrap_content"
+        android:orientation="horizontal">
 
         <TextView
+            android:id="@+id/nameTextView"
+            style="@style/RowTitle"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
-            style="@style/RowTitle"
-            android:id="@+id/nameTextView"
             android:layout_weight="1" />
 
         <TextView
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
+            android:id="@+id/memberCountTextView"
             style="@style/RowText"
-            android:id="@+id/memberCountTextView" />
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content" />
     </LinearLayout>
 
     <LinearLayout
-        android:orientation="horizontal"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content">
+        android:layout_height="wrap_content"
+        android:orientation="horizontal">
 
         <TextView
+            android:id="@+id/descriptionTextView"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
-            android:text="New Text"
-            android:id="@+id/descriptionTextView"
-            android:layout_weight="1" />
+            android:layout_weight="1"
+            android:text="New Text" />
 
         <Button
+            android:id="@+id/joinleaveButton"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:text="New Button"
-            android:id="@+id/joinleaveButton" />
+            android:text="New Button" />
     </LinearLayout>
 </LinearLayout>

--- a/Habitica/src/main/java/com/habitrpg/android/habitica/ui/fragments/social/GuildFragment.java
+++ b/Habitica/src/main/java/com/habitrpg/android/habitica/ui/fragments/social/GuildFragment.java
@@ -93,7 +93,16 @@ public class GuildFragment extends BaseMainFragment implements Callback<Group> {
                 this.isMember = true;
                 return true;
             case R.id.menu_guild_leave:
-                this.mAPIHelper.apiService.leaveGroup(this.guild.id, this);
+                this.mAPIHelper.apiService.leaveGroup(this.guild.id, new Callback<Void>() {
+                    @Override
+                    public void success(Void aVoid, Response response) {
+                        getActivity().supportInvalidateOptionsMenu();
+                    }
+
+                    @Override
+                    public void failure(RetrofitError error) {
+                    }
+                });
                 this.isMember = false;
                 return true;
             case R.id.menu_guild_edit:

--- a/Habitica/src/main/java/com/habitrpg/android/habitica/ui/fragments/social/party/PartyFragment.java
+++ b/Habitica/src/main/java/com/habitrpg/android/habitica/ui/fragments/social/party/PartyFragment.java
@@ -135,9 +135,9 @@ public class PartyFragment extends BaseMainFragment {
                 this.displayEditForm();
                 return true;
             case R.id.menu_guild_leave:
-                this.mAPIHelper.apiService.leaveGroup(this.group.id, new Callback<Group>() {
+                this.mAPIHelper.apiService.leaveGroup(this.group.id, new Callback<Void>() {
                     @Override
-                    public void success(Group group, Response response) {
+                    public void success(Void aVoid, Response response) {
                         getActivity().getSupportFragmentManager().beginTransaction().remove(PartyFragment.this).commit();
                     }
 

--- a/Habitica/src/main/java/com/magicmicky/habitrpgwrapper/lib/api/ApiService.java
+++ b/Habitica/src/main/java/com/magicmicky/habitrpgwrapper/lib/api/ApiService.java
@@ -145,7 +145,7 @@ public interface ApiService {
     void joinGroup(@Path("gid") String groupId, Callback<Group> cb);
 
     @POST("/groups/{gid}/leave")
-    void leaveGroup(@Path("gid") String groupId, Callback<Group> cb);
+    void leaveGroup(@Path("gid") String groupId, Callback<Void> cb);
 
     @POST("/groups/{gid}/chat")
     void postGroupChat(@Path("gid") String groupId, @Query("message") String message, Callback<PostChatMessageResult> cb);

--- a/Habitica/src/main/java/com/magicmicky/habitrpgwrapper/lib/models/Group.java
+++ b/Habitica/src/main/java/com/magicmicky/habitrpgwrapper/lib/models/Group.java
@@ -40,4 +40,21 @@ public class Group extends BaseModel {
     public int challengeCount;
 
     // TODO Challenges
+
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        Group group = (Group) o;
+
+        return id != null ? id.equals(group.id) : group.id == null;
+
+    }
+
+    @Override
+    public int hashCode() {
+        return id != null ? id.hashCode() : 0;
+    }
 }


### PR DESCRIPTION

my Habitica User-ID: f52b69aa-b48c-4db8-b8ca-7d9c43d84a42

So, this one fixes an issue where if you were to Join or Leave a guild while viewing the public list, it would not actually update the UI at all. This took a bit of refactoring to get working mostly due to the fact that the ViewHolder was keeping track of things that belonged in the Adapter. Typically, it is best practice to perform API actions within the fragment or activity so that the adapter or view holder just keep up with UI state. In this case, I merely refactored the API updating logic to be within the adapter, with the click listeners defined within the adapter. When a click occurs, the Group associated with the view holder is pulled from the view holders tag and the API operation is perfomed within the adapter. When the operation completes, `notifyItemChanged` is called on the items position so that only one item in the list will update. 

I also went ahead and updated the API call to leave a group so that it was correctly returning Void instead of a Group (as defined in the 204 response code). This was mostly for my own sanity, since I was first attempting to read that returned group when the user left the group and it was resulting in some null pointer exceptions.

I also added an `equals` and `hashcode` methods on the Group model so that I could check a group coming back from the API (different object) against a group in the list. These methods were autogenerated within Android Studio and read just the `id` of the group.

Some of the XML changes are just my autoformatter going nuts, sorry about that.