### PR TITLE
Added null check and use Integer object type for maxHp

### DIFF
--- a/Habitica/src/main/java/com/habitrpg/android/habitica/ui/AvatarWithBarsViewModel.java
+++ b/Habitica/src/main/java/com/habitrpg/android/habitica/ui/AvatarWithBarsViewModel.java
@@ -138,8 +138,8 @@ public class AvatarWithBarsViewModel implements View.OnClickListener {
     }
 
     public static void setHpBarData(ValueBarBinding valueBar, Stats stats, Context ctx) {
-        int maxHP = stats.getMaxHealth();
-        if (maxHP == 0) {
+        Integer maxHP = stats.getMaxHealth();
+        if ((maxHP == null) || maxHP.equals(0)) {
             maxHP = 50;
         }
 


### PR DESCRIPTION

my Habitica User-ID:

I was getting a crash when loading marty members -
- After checking that the Stats model can have a null maxHP add a null check
- User the Integer return type instead of int primitive to capture the null value 