### PR TITLE
Fixed issue with displaying onboarding when user registers with facebook from the login screen

### DIFF
--- a/Habitica/src/main/java/com/habitrpg/android/habitica/ui/activities/LoginActivity.java
+++ b/Habitica/src/main/java/com/habitrpg/android/habitica/ui/activities/LoginActivity.java
@@ -363,7 +363,8 @@ public class LoginActivity extends BaseActivity
         } catch (Exception e) {
             e.printStackTrace();
         }
-        if (this.isRegistering) {
+        
+        if (this.isRegistering || userAuthResponse.getNewUser()) {
             this.startSetupActivity();
         } else {
             JSONObject eventProperties = new JSONObject();

--- a/Habitica/src/main/java/com/magicmicky/habitrpgwrapper/lib/models/UserAuthResponse.java
+++ b/Habitica/src/main/java/com/magicmicky/habitrpgwrapper/lib/models/UserAuthResponse.java
@@ -7,6 +7,7 @@ public class UserAuthResponse {
     //we need apiToken and token, as both are possible returns
     private String apiToken;
     private String token;
+    private Boolean newUser = false;
     private String id;
 
     public String getToken() {
@@ -35,5 +36,13 @@ public class UserAuthResponse {
 
     public void setId(String id) {
         this.id = id;
+    }
+
+    public Boolean getNewUser() {
+        return newUser;
+    }
+
+    public void setNewUser(Boolean newUser) {
+        this.newUser = newUser;
     }
 }


### PR DESCRIPTION

my Habitica User-ID:

IF a user starts on the login screen, and clicks "Login with facebook" the will miss the onboarding screen if they are a new account. This plus a PR on the web side will fix that issue. 