### PR TITLE
Fix #617, #618: Correct profile's pet/mount counts

### DIFF
--- a/Habitica/res/layout/activity_full_profile.xml
+++ b/Habitica/res/layout/activity_full_profile.xml
@@ -2,6 +2,7 @@
 <ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:fresco="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/fullprofile_scrollview"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
@@ -328,10 +329,10 @@
                             android:text="@string/profile_pets_found" />
 
                         <TextView
-                            android:id="@+id/profile_pet_count"
+                            android:id="@+id/profile_pets_found_count"
                             android:layout_width="match_parent"
                             android:layout_height="wrap_content"
-                            android:text="#" />
+                            tools:text="#" />
                     </TableRow>
 
                     <TableRow android:layout_height="wrap_content">
@@ -342,10 +343,10 @@
                             android:text="@string/profile_mounts_tamed" />
 
                         <TextView
-                            android:id="@+id/profile_mount_count"
+                            android:id="@+id/profile_mounts_tamed_count"
                             android:layout_width="match_parent"
                             android:layout_height="wrap_content"
-                            android:text="#" />
+                            tools:text="#" />
                     </TableRow>
                 </TableLayout>
             </LinearLayout>

--- a/Habitica/src/main/java/com/habitrpg/android/habitica/ui/activities/FullProfileActivity.java
+++ b/Habitica/src/main/java/com/habitrpg/android/habitica/ui/activities/FullProfileActivity.java
@@ -100,11 +100,11 @@ public class FullProfileActivity extends BaseActivity {
     @BindView(R.id.fullprofile_scrollview)
     ScrollView fullprofile_scrollview;
 
-    @BindView(R.id.profile_pet_count)
-    TextView petCount;
+    @BindView(R.id.profile_pets_found_count)
+    TextView petsFoundCount;
 
-    @BindView(R.id.profile_mount_count)
-    TextView mountCount;
+    @BindView(R.id.profile_mounts_tamed_count)
+    TextView mountsTamedCount;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -222,24 +222,8 @@ public class FullProfileActivity extends BaseActivity {
 
         addLevelAttributes(stats, user);
 
-        petCount.setText(String.valueOf(countEntries(user.getItems().getPets())));
-        mountCount.setText(String.valueOf(countEntries(user.getItems().getMounts())));
-    }
-
-    private int countEntries(HashMap<String, ?> hashMap) {
-        if(hashMap == null)
-            return 0;
-
-        int _count = 0;
-
-        for (Map.Entry<String, ?> e : hashMap.entrySet()) {
-            if (e.getValue() == null)
-                continue;
-
-            _count += 1;
-        }
-
-        return _count;
+        petsFoundCount.setText(String.valueOf(user.getPetsFoundCount()));
+        mountsTamedCount.setText(String.valueOf(user.getMountsTamedCount()));
     }
 
     // region Utils

--- a/Habitica/src/main/java/com/magicmicky/habitrpgwrapper/lib/models/HabitRPGUser.java
+++ b/Habitica/src/main/java/com/magicmicky/habitrpgwrapper/lib/models/HabitRPGUser.java
@@ -22,6 +22,7 @@ import android.text.TextUtils;
 import java.util.ArrayList;
 import java.util.EnumMap;
 import java.util.List;
+import java.util.Map;
 
 @Table(databaseName = HabitDatabase.NAME)
 public class HabitRPGUser extends BaseModel {
@@ -500,5 +501,23 @@ public class HabitRPGUser extends BaseModel {
         }
 
         return layerMap;
+    }
+
+    public int getPetsFoundCount() {
+        return getNullableMapSize(items.getPets());
+    }
+
+    public int getMountsTamedCount() {
+        return getNullableMapSize(items.getMounts());
+    }
+
+    private int getNullableMapSize(Map map) {
+        int mapSize = 0;
+
+        if (map != null) {
+            mapSize = map.size();
+        }
+
+        return mapSize;
     }
 }

--- a/Habitica/src/test/java/com/magicmicky/habitrpgwrapper/lib/models/HabitRPGUserTest.java
+++ b/Habitica/src/test/java/com/magicmicky/habitrpgwrapper/lib/models/HabitRPGUserTest.java
@@ -1,0 +1,63 @@
+package com.magicmicky.habitrpgwrapper.lib.models;
+
+import com.habitrpg.android.habitica.BuildConfig;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricGradleTestRunner;
+import org.robolectric.annotation.Config;
+
+import java.util.HashMap;
+
+import static org.junit.Assert.*;
+
+@Config(constants = BuildConfig.class)
+@RunWith(RobolectricGradleTestRunner.class)
+public class HabitRPGUserTest {
+
+    private HabitRPGUser user;
+
+    @Before
+    public void setup() {
+        user = new HabitRPGUser();
+        Items items = new Items();
+        user.setItems(items);
+    }
+
+    @Test
+    public void getPetsFoundCount_shouldReturnSumOfAllPetEntries() {
+        HashMap<String, Integer> pets = new HashMap<>();
+        pets.put("BearCub-Base", 0);
+        pets.put("Sheep-Base", 5);
+        pets.put("Cheetah-Shade", 35);
+        pets.put("Slime-Base", -1);
+        pets.put("Axolotl-Red", 5);
+
+        user.getItems().setPets(pets);
+        assertEquals(5, user.getPetsFoundCount());
+    }
+
+    @Test
+    public void getPetsFoundCount_onNoPetCollectionAvailable_shouldReturnZero() {
+        assertEquals(0, user.getPetsFoundCount());
+    }
+
+    @Test
+    public void getMountsTamedCount_shouldReturnSumOfAllMountEntries() {
+        HashMap<String, Boolean> mounts = new HashMap<>();
+        mounts.put("BearCub-White", null);
+        mounts.put("BearCub-CottonCandyPink", true);
+        mounts.put("Seahorse-Base", true);
+        mounts.put("Owl-Zombie", true);
+        mounts.put("Cactus-White", null);
+
+        user.getItems().setMounts(mounts);
+        assertEquals(5, user.getMountsTamedCount());
+    }
+
+    @Test
+    public void getMountsTamedCount_onNoMountCollectionAvailable_shouldReturnZero() {
+        assertEquals(0, user.getMountsTamedCount());
+    }
+}


### PR DESCRIPTION

my Habitica User-ID: 540ca157-ca25-457e-8e32-9f8a3a8778b9

The profile's mounts tamed count wrongly ignores mounts with null value.

Also, null/nonexistent pet/mount collections have counts showing as "#".

Both counts should instead be shown as 0 for such null collections.

This fix matches the web app, which does the following:
1. Mounts tamed count = sum mount entries with any value (true, null)
2. Nonexistent pet/mount collections have counts showing as 0

Fix #617, #618